### PR TITLE
Support custom rpc node on `get-collection-ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,19 @@ yarn install
 ```
 
 ```
-ts-node index.ts <collection_id>
+ts-node index.ts <collection_id> <rpc_node>
 ```
 
 Example:
 
 ```
 ts-node index.ts 66gy1CNSpMzTtf6P8CFGY1mo5K3n7wn2bE249p31tehv
+```
+
+or with custom rpc node
+
+```
+ts-node index.ts 66gy1CNSpMzTtf6P8CFGY1mo5K3n7wn2bE249p31tehv https://api.metaplex.solana.com/
 ```
 
 Outputs the list of mints to a file named `<collection_id>_mints.json`.

--- a/get-collection-ts/index.ts
+++ b/get-collection-ts/index.ts
@@ -7,8 +7,11 @@ const {
 } = programs;
 
 async function main() {
-  let connection = new Connection("https://api.metaplex.com", "confirmed");
-  let collection_id = new PublicKey(process.argv.slice(2, 3)[0]);
+  // Get command line arguments
+  const args = process.argv.slice(2, 4)
+
+  let connection = new Connection(args[1] || "https://api.metaplex.com", "confirmed");
+  let collection_id = new PublicKey(args[0])
   let metaplexProgramId = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s";
 
   console.log("Getting signatures...");


### PR DESCRIPTION
Currently we can't use a custom RPC node url when using `get-collection-ts`, the default node https://api.metaplex.com/ isn't working anymore so we can't fetch mint addresses at all using the Typescript version.

This pull request let us use a custom node url, if it's not specified it will use the default Metaplex one instead.